### PR TITLE
chore: update pinned dependency digests/SHAs

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: container-factory-runner
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Inject Nexus CA (Bootstrap)
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
       
       - name: Send Start Notification
         continue-on-error: true
-        uses: gillouche/homelab-ci/actions/discord-notify@main
+        uses: gillouche/homelab-ci/actions/discord-notify@08d173d21e18c50cfde249a7904ae8a62366c6fe # main
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_GITHUB_ACTIONS }}
           status: info
@@ -53,7 +53,7 @@ jobs:
             ]
 
       - name: Setup Nix Environment
-        uses: gillouche/homelab-ci/actions/setup-nix-env@main
+        uses: gillouche/homelab-ci/actions/setup-nix-env@08d173d21e18c50cfde249a7904ae8a62366c6fe # main
         with:
           access-key-id: ${{ secrets.NIX_CACHE_ACCESS_KEY }}
           secret-access-key: ${{ secrets.NIX_CACHE_SECRET_KEY }}
@@ -151,7 +151,7 @@ jobs:
 
       - name: Send Completion Notification
         continue-on-error: true
-        uses: gillouche/homelab-ci/actions/discord-notify@main
+        uses: gillouche/homelab-ci/actions/discord-notify@08d173d21e18c50cfde249a7904ae8a62366c6fe # main
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_GITHUB_ACTIONS }}
           status: ${{ steps.status.outputs.status }}

--- a/.github/workflows/check-pinned-deps.yaml
+++ b/.github/workflows/check-pinned-deps.yaml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.PR_TOKEN }}
 
       - name: Setup Nix Environment
-        uses: gillouche/homelab-ci/actions/setup-nix-env@main
+        uses: gillouche/homelab-ci/actions/setup-nix-env@08d173d21e18c50cfde249a7904ae8a62366c6fe # main
         with:
           access-key-id: ${{ secrets.NIX_CACHE_ACCESS_KEY }}
           secret-access-key: ${{ secrets.NIX_CACHE_SECRET_KEY }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Notify Discord — updates available
         if: steps.check.outputs.updates != '0'
-        uses: gillouche/homelab-ci/actions/discord-notify@main
+        uses: gillouche/homelab-ci/actions/discord-notify@08d173d21e18c50cfde249a7904ae8a62366c6fe # main
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_SECURITY_NOTIFICATIONS }}
           title: "Pinned Dependency Updates Available"
@@ -69,7 +69,7 @@ jobs:
 
       - name: Notify Discord — unpinned dependencies only
         if: steps.check.outputs.updates == '0' && steps.check.outputs.warnings != '0'
-        uses: gillouche/homelab-ci/actions/discord-notify@main
+        uses: gillouche/homelab-ci/actions/discord-notify@08d173d21e18c50cfde249a7904ae8a62366c6fe # main
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_SECURITY_NOTIFICATIONS }}
           title: "Unpinned Dependencies Detected"
@@ -89,7 +89,7 @@ jobs:
 
       - name: Notify Discord — all up to date
         if: steps.check.outputs.updates == '0' && steps.check.outputs.warnings == '0'
-        uses: gillouche/homelab-ci/actions/discord-notify@main
+        uses: gillouche/homelab-ci/actions/discord-notify@08d173d21e18c50cfde249a7904ae8a62366c6fe # main
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_SECURITY_NOTIFICATIONS }}
           title: "All Pinned Dependencies Up To Date"

--- a/.github/workflows/renovate-notify.yaml
+++ b/.github/workflows/renovate-notify.yaml
@@ -12,7 +12,7 @@ jobs:
     if: (startsWith(github.head_ref, 'renovate/') || github.event.pull_request.user.login == 'renovate[bot]') && github.repository_owner == 'gillouche'
     runs-on: ubuntu-latest
     steps:
-      - uses: gillouche/homelab-ci/actions/renovate-notify@main
+      - uses: gillouche/homelab-ci/actions/renovate-notify@08d173d21e18c50cfde249a7904ae8a62366c6fe # main
         with:
           webhook: ${{ secrets.DISCORD_RENOVATE_WEBHOOK }}
           pr-title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Nix Environment
-        uses: gillouche/homelab-ci/actions/setup-nix-env@main
+        uses: gillouche/homelab-ci/actions/setup-nix-env@08d173d21e18c50cfde249a7904ae8a62366c6fe # main
         with:
           access-key-id: ${{ secrets.NIX_CACHE_ACCESS_KEY }}
           secret-access-key: ${{ secrets.NIX_CACHE_SECRET_KEY }}
@@ -65,7 +65,7 @@ jobs:
         run: nix develop --command bash -c "echo \$PATH >> \$GITHUB_PATH"
 
       - name: Trivy Scan
-        uses: gillouche/homelab-ci/actions/trivy-scan@main
+        uses: gillouche/homelab-ci/actions/trivy-scan@08d173d21e18c50cfde249a7904ae8a62366c6fe # main
         with:
           image: ${{ steps.build.outputs.image_full }}
           trivyignore: images/${{ inputs.image }}/.trivyignore
@@ -73,7 +73,7 @@ jobs:
 
       - name: Push Notification
         if: steps.build.outputs.pushed == 'true'
-        uses: gillouche/homelab-ci/actions/push-notify@main
+        uses: gillouche/homelab-ci/actions/push-notify@08d173d21e18c50cfde249a7904ae8a62366c6fe # main
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_SECURITY }}
           image: ${{ inputs.image }}

--- a/bootstrap/arc-runner/Dockerfile
+++ b/bootstrap/arc-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/actions/actions-runner:latest
+FROM ghcr.io/actions/actions-runner:latest@sha256:dced476aa42703ebd9aafc295ce52f160989c4528e831fc3be2aef83a1b3f6da
 
 # Switch to root to install dependencies
 USER root

--- a/images/actions-runner/Dockerfile
+++ b/images/actions-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/wolfi-base:latest AS build
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:1c56f3ceb1c9929611a1cc7ab7a5fde1ec5df87add282029cd1596b8eae5af67 AS build
 
 ARG TARGETARCH
 ARG VERSION=2.331.0
@@ -38,7 +38,7 @@ RUN DOCKER_ARCH="${TARGETARCH}" \
     "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${TARGETARCH}" \
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
 
-FROM cgr.dev/chainguard/wolfi-base:latest
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:1c56f3ceb1c9929611a1cc7ab7a5fde1ec5df87add282029cd1596b8eae5af67
 
 ARG VERSION=2.331.0
 ARG RUNNER_UID=1001


### PR DESCRIPTION
## Summary

Automated update of pinned dependency digests and/or SHAs detected by the nightly dependency checker.

### Updated dependencies

- **cgr.dev/chainguard/wolfi-base:latest** in `images/actions-runner/Dockerfile` (Pinned)
  - `unpinned` -> `sha256:1c56f3ceb1c9...`
- **cgr.dev/chainguard/wolfi-base:latest** in `images/actions-runner/Dockerfile` (Pinned)
  - `unpinned` -> `sha256:1c56f3ceb1c9...`
- **nexus.gillouche.homelab/docker-hosted/base/actions-runner:2.331.0** in `images/actions-runner-homelab-nix/Dockerfile` (Pinned)
  - `unpinned` -> `sha256:0e7a901e21b2...`
- **nexus.gillouche.homelab/docker-hub/python:3.13-slim-trixie** in `images/python-distroless/Dockerfile` (Pinned)
  - `unpinned` -> `sha256:3de9a8d7aedb...`
- **ghcr.io/actions/actions-runner:latest** in `bootstrap/arc-runner/Dockerfile` (Pinned)
  - `unpinned` -> `sha256:dced476aa427...`
- **gillouche/homelab-ci/actions/setup-nix-env@main** in `.github/workflows/reusable-build.yaml` (Pinned)
  - `unpinned` -> `08d173d21e18`
- **gillouche/homelab-ci/actions/trivy-scan@main** in `.github/workflows/reusable-build.yaml` (Pinned)
  - `unpinned` -> `08d173d21e18`
- **gillouche/homelab-ci/actions/push-notify@main** in `.github/workflows/reusable-build.yaml` (Pinned)
  - `unpinned` -> `08d173d21e18`
- **gillouche/homelab-ci/actions/discord-notify@main** in `.github/workflows/build.yaml` (Pinned)
  - `unpinned` -> `08d173d21e18`
- **gillouche/homelab-ci/actions/setup-nix-env@main** in `.github/workflows/build.yaml` (Pinned)
  - `unpinned` -> `08d173d21e18`
- **gillouche/homelab-ci/actions/discord-notify@main** in `.github/workflows/build.yaml` (Pinned)
  - `unpinned` -> `08d173d21e18`
- **actions/checkout@v4** in `.github/workflows/bootstrap.yaml` (Pinned)
  - `unpinned` -> `34e114876b0b`
- **gillouche/homelab-ci/actions/setup-nix-env@main** in `.github/workflows/check-pinned-deps.yaml` (Pinned)
  - `unpinned` -> `08d173d21e18`
- **gillouche/homelab-ci/actions/discord-notify@main** in `.github/workflows/check-pinned-deps.yaml` (Pinned)
  - `unpinned` -> `08d173d21e18`
- **gillouche/homelab-ci/actions/discord-notify@main** in `.github/workflows/check-pinned-deps.yaml` (Pinned)
  - `unpinned` -> `08d173d21e18`
- **gillouche/homelab-ci/actions/discord-notify@main** in `.github/workflows/check-pinned-deps.yaml` (Pinned)
  - `unpinned` -> `08d173d21e18`
- **gillouche/homelab-ci/actions/renovate-notify@main** in `.github/workflows/renovate-notify.yaml` (Pinned)
  - `unpinned` -> `08d173d21e18`

## Test plan

- [ ] Verify updated digests/SHAs resolve correctly
- [ ] Confirm nightly build passes with updated dependencies

Generated by the nightly pinned dependency checker