### PR TITLE
update: pinned dependency digests/SHAs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
       
       - name: Send Start Notification
         continue-on-error: true
-        uses: gillouche/homelab-ci/actions/discord-notify@main # main
+        uses: gillouche/homelab-ci/actions/discord-notify@f5723a407eabc03e294948b3b1dd86c880c7c77a # main # main
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_GITHUB_ACTIONS }}
           status: info
@@ -53,14 +53,14 @@ jobs:
             ]
 
       - name: Setup Nix Cache Profile
-        uses: gillouche/homelab-ci/actions/setup-aws-profile@main
+        uses: gillouche/homelab-ci/actions/setup-aws-profile@f5723a407eabc03e294948b3b1dd86c880c7c77a # main
         with:
           profile: "nix"
           access-key-id: ${{ secrets.NIX_CACHE_ACCESS_KEY }}
           secret-access-key: ${{ secrets.NIX_CACHE_SECRET_KEY }}
 
       - name: Setup Nix Environment
-        uses: gillouche/homelab-ci/actions/setup-nix-env@main
+        uses: gillouche/homelab-ci/actions/setup-nix-env@f5723a407eabc03e294948b3b1dd86c880c7c77a # main
 
       - name: Push Dev Environment to Nix Cache
         run: |
@@ -152,7 +152,7 @@ jobs:
 
       - name: Send Completion Notification
         continue-on-error: true
-        uses: gillouche/homelab-ci/actions/discord-notify@main # main
+        uses: gillouche/homelab-ci/actions/discord-notify@f5723a407eabc03e294948b3b1dd86c880c7c77a # main # main
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_GITHUB_ACTIONS }}
           status: ${{ steps.status.outputs.status }}

--- a/.github/workflows/check-pinned-deps.yaml
+++ b/.github/workflows/check-pinned-deps.yaml
@@ -19,14 +19,14 @@ jobs:
           token: ${{ secrets.PR_TOKEN }}
 
       - name: Setup Nix Cache Profile
-        uses: gillouche/homelab-ci/actions/setup-aws-profile@main
+        uses: gillouche/homelab-ci/actions/setup-aws-profile@f5723a407eabc03e294948b3b1dd86c880c7c77a # main
         with:
           profile: "nix"
           access-key-id: ${{ secrets.NIX_CACHE_ACCESS_KEY }}
           secret-access-key: ${{ secrets.NIX_CACHE_SECRET_KEY }}
 
       - name: Setup Nix Environment
-        uses: gillouche/homelab-ci/actions/setup-nix-env@main
+        uses: gillouche/homelab-ci/actions/setup-nix-env@f5723a407eabc03e294948b3b1dd86c880c7c77a # main
 
       - name: Check pinned dependencies
         id: check
@@ -67,7 +67,7 @@ jobs:
 
       - name: Notify Discord — updates available
         if: steps.check.outputs.updates != '0'
-        uses: gillouche/homelab-ci/actions/discord-notify@main # main
+        uses: gillouche/homelab-ci/actions/discord-notify@f5723a407eabc03e294948b3b1dd86c880c7c77a # main # main
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_SECURITY_NOTIFICATIONS }}
           title: "Pinned Dependency Updates Available"
@@ -87,7 +87,7 @@ jobs:
 
       - name: Notify Discord — unpinned dependencies only
         if: steps.check.outputs.updates == '0' && steps.check.outputs.warnings != '0'
-        uses: gillouche/homelab-ci/actions/discord-notify@main # main
+        uses: gillouche/homelab-ci/actions/discord-notify@f5723a407eabc03e294948b3b1dd86c880c7c77a # main # main
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_SECURITY_NOTIFICATIONS }}
           title: "Unpinned Dependencies Detected"
@@ -107,7 +107,7 @@ jobs:
 
       - name: Notify Discord — all up to date
         if: steps.check.outputs.updates == '0' && steps.check.outputs.warnings == '0'
-        uses: gillouche/homelab-ci/actions/discord-notify@main # main
+        uses: gillouche/homelab-ci/actions/discord-notify@f5723a407eabc03e294948b3b1dd86c880c7c77a # main # main
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_SECURITY_NOTIFICATIONS }}
           title: "All Pinned Dependencies Up To Date"

--- a/.github/workflows/renovate-notify.yaml
+++ b/.github/workflows/renovate-notify.yaml
@@ -12,7 +12,7 @@ jobs:
     if: (startsWith(github.head_ref, 'renovate/') || github.event.pull_request.user.login == 'renovate[bot]') && github.repository_owner == 'gillouche'
     runs-on: ubuntu-latest
     steps:
-      - uses: gillouche/homelab-ci/actions/renovate-notify@main # main
+      - uses: gillouche/homelab-ci/actions/renovate-notify@f5723a407eabc03e294948b3b1dd86c880c7c77a # main # main
         with:
           webhook: ${{ secrets.DISCORD_RENOVATE_WEBHOOK }}
           pr-title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -30,14 +30,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Nix Cache Profile
-        uses: gillouche/homelab-ci/actions/setup-aws-profile@main
+        uses: gillouche/homelab-ci/actions/setup-aws-profile@f5723a407eabc03e294948b3b1dd86c880c7c77a # main
         with:
           profile: "nix"
           access-key-id: ${{ secrets.NIX_CACHE_ACCESS_KEY }}
           secret-access-key: ${{ secrets.NIX_CACHE_SECRET_KEY }}
 
       - name: Setup Nix Environment
-        uses: gillouche/homelab-ci/actions/setup-nix-env@main
+        uses: gillouche/homelab-ci/actions/setup-nix-env@f5723a407eabc03e294948b3b1dd86c880c7c77a # main
 
       - name: Inject Nexus CA into Docker Daemon
         run: |
@@ -67,7 +67,7 @@ jobs:
         run: nix develop --command bash -c "echo \$PATH >> \$GITHUB_PATH"
 
       - name: Trivy Scan
-        uses: gillouche/homelab-ci/actions/trivy-scan@main # main
+        uses: gillouche/homelab-ci/actions/trivy-scan@f5723a407eabc03e294948b3b1dd86c880c7c77a # main # main
         with:
           image: ${{ steps.build.outputs.image_full }}
           trivyignore: images/${{ inputs.image }}/.trivyignore
@@ -75,7 +75,7 @@ jobs:
 
       - name: Push Notification
         if: steps.build.outputs.pushed == 'true'
-        uses: gillouche/homelab-ci/actions/push-notify@main # main
+        uses: gillouche/homelab-ci/actions/push-notify@f5723a407eabc03e294948b3b1dd86c880c7c77a # main # main
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_SECURITY }}
           image: ${{ inputs.image }}


### PR DESCRIPTION
## Summary

Automated update of pinned dependency digests and/or SHAs detected by the nightly dependency checker.

### Updated dependencies

- **gillouche/homelab-ci/actions/setup-nix-env@main** in `.github/workflows/reusable-build.yaml` (Pinned)
  - `unpinned` -> `ff9cab8107f0`
- **gillouche/homelab-ci/actions/trivy-scan@main** in `.github/workflows/reusable-build.yaml` (Pinned)
  - `unpinned` -> `ff9cab8107f0`
- **gillouche/homelab-ci/actions/push-notify@main** in `.github/workflows/reusable-build.yaml` (Pinned)
  - `unpinned` -> `ff9cab8107f0`
- **gillouche/homelab-ci/actions/discord-notify@main** in `.github/workflows/build.yaml` (Pinned)
  - `unpinned` -> `ff9cab8107f0`
- **gillouche/homelab-ci/actions/setup-nix-env@main** in `.github/workflows/build.yaml` (Pinned)
  - `unpinned` -> `ff9cab8107f0`
- **gillouche/homelab-ci/actions/discord-notify@main** in `.github/workflows/build.yaml` (Pinned)
  - `unpinned` -> `ff9cab8107f0`
- **gillouche/homelab-ci/actions/setup-nix-env@main** in `.github/workflows/check-pinned-deps.yaml` (Pinned)
  - `unpinned` -> `ff9cab8107f0`
- **gillouche/homelab-ci/actions/discord-notify@main** in `.github/workflows/check-pinned-deps.yaml` (Pinned)
  - `unpinned` -> `ff9cab8107f0`
- **gillouche/homelab-ci/actions/discord-notify@main** in `.github/workflows/check-pinned-deps.yaml` (Pinned)
  - `unpinned` -> `ff9cab8107f0`
- **gillouche/homelab-ci/actions/discord-notify@main** in `.github/workflows/check-pinned-deps.yaml` (Pinned)
  - `unpinned` -> `ff9cab8107f0`
- **gillouche/homelab-ci/actions/renovate-notify@main** in `.github/workflows/renovate-notify.yaml` (Pinned)
  - `unpinned` -> `ff9cab8107f0`

## Test plan

- [ ] Verify updated digests/SHAs resolve correctly
- [ ] Confirm nightly build passes with updated dependencies

Generated by the nightly pinned dependency checker